### PR TITLE
Auth 707 platform force token invalidation in salesforce

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.springframework.social</groupId>
     <artifactId>spring-social-salesforce</artifactId>
-    <version>1.2.3.RELEASE</version>
+    <version>1.2.4.RELEASE</version>
     <packaging>jar</packaging>
 
     <name>spring-social-salesforce</name>

--- a/src/main/java/org/springframework/social/salesforce/connect/SalesforceOAuth2Template.java
+++ b/src/main/java/org/springframework/social/salesforce/connect/SalesforceOAuth2Template.java
@@ -29,8 +29,8 @@ import org.springframework.web.context.request.ServletRequestAttributes;
  */
 public class SalesforceOAuth2Template extends OAuth2Template
 {
-    private static final String FORCE_LOGIN_PROMPT_REQUEST_PARAMETER = "forceLoginPrompt";
-    private static final String SELECT_ACCOUNT_PROMPT_REQUEST_PARAMETER = "selectAccountPrompt";
+    public static final String FORCE_LOGIN_PROMPT_REQUEST_PARAMETER = "forceLoginPrompt";
+    public static final String SELECT_ACCOUNT_PROMPT_REQUEST_PARAMETER = "selectAccountPrompt";
 
     private ThreadLocal<String> instanceUrl = new ThreadLocal<String>();
     private ClientHttpRequestFactory clientHttpRequestFactory;

--- a/src/main/java/org/springframework/social/salesforce/connect/SalesforceOAuth2Template.java
+++ b/src/main/java/org/springframework/social/salesforce/connect/SalesforceOAuth2Template.java
@@ -16,7 +16,6 @@ import org.springframework.social.oauth2.OAuth2Parameters;
 import org.springframework.social.oauth2.OAuth2Template;
 import org.springframework.social.salesforce.connect.oauth2.SalesforceAccessGrant;
 import org.springframework.social.support.LoggingErrorHandler;
-import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -30,6 +29,9 @@ import org.springframework.web.context.request.ServletRequestAttributes;
  */
 public class SalesforceOAuth2Template extends OAuth2Template
 {
+    private static final String FORCE_LOGIN_PROMPT_REQUEST_PARAMETER = "forceLoginPrompt";
+    private static final String SELECT_ACCOUNT_PROMPT_REQUEST_PARAMETER = "selectAccountPrompt";
+
     private ThreadLocal<String> instanceUrl = new ThreadLocal<String>();
     private ClientHttpRequestFactory clientHttpRequestFactory;
 
@@ -90,12 +92,12 @@ public class SalesforceOAuth2Template extends OAuth2Template
         ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
         HttpServletRequest request = servletRequestAttributes.getRequest();
         if (request != null) {
-            if (request.getParameter("forceLoginPrompt") != null) {
-                parameters.add("prompt", "login");
-            }
-            String salesforceUsernameHint = request.getParameter("usernameHint");
-            if (StringUtils.hasText(salesforceUsernameHint)) {
-                parameters.add("login_hint", salesforceUsernameHint);
+            if (request.getParameter(FORCE_LOGIN_PROMPT_REQUEST_PARAMETER) != null
+                    || request.getParameter(SELECT_ACCOUNT_PROMPT_REQUEST_PARAMETER) != null) {
+
+                String promptParameterValue = request.getParameter(FORCE_LOGIN_PROMPT_REQUEST_PARAMETER) != null ? "login"
+                                                                                                                 : "select_account";
+                parameters.add("prompt", promptParameterValue);
             }
         }
         return super.buildAuthenticateUrl(parameters);

--- a/src/main/java/org/springframework/social/salesforce/connect/SalesforceOAuth2Template.java
+++ b/src/main/java/org/springframework/social/salesforce/connect/SalesforceOAuth2Template.java
@@ -94,7 +94,6 @@ public class SalesforceOAuth2Template extends OAuth2Template
         if (request != null) {
             if (request.getParameter(FORCE_LOGIN_PROMPT_REQUEST_PARAMETER) != null
                     || request.getParameter(SELECT_ACCOUNT_PROMPT_REQUEST_PARAMETER) != null) {
-
                 String promptParameterValue = request.getParameter(FORCE_LOGIN_PROMPT_REQUEST_PARAMETER) != null ? "login"
                                                                                                                  : "select_account";
                 parameters.add("prompt", promptParameterValue);


### PR DESCRIPTION
* Insert prompt=login when forceLoginPrompt is present in request
* Insert prompt=select_account when selectAccountPrompt is preswent in request
* If forceLoginPrompt and selectAccountPrompt are both presents, only prompt=login will be added in request to salesforce login

+ Bump to 1.2.4.RELEASE version